### PR TITLE
Added dependency to Terrain

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "unity": "2022.3",
   "unityRelease": "0f1",
   "dependencies": {
+    "com.unity.editorcoroutines": "1.0.0",
     "com.unity.mathematics": "1.2.6",
-    "com.unity.splines": "2.4.0",
-    "com.unity.editorcoroutines": "1.0.0"
+    "com.unity.modules.terrain": "1.0.0",
+    "com.unity.splines": "2.4.0"
   },
   "keywords": [
     "foliage",


### PR DESCRIPTION
Some people, like me, disable built-in packages. Packages that depend on them without declaring it will break in that case.